### PR TITLE
Update forge overview link

### DIFF
--- a/doc/PRE_INSTALL.md
+++ b/doc/PRE_INSTALL.md
@@ -1,3 +1,3 @@
 This app requires a connection to a Git forge configured at installation time.
 
-Visit <https://woodpecker-ci.org/docs/administration/forges/overview> for details about retrieving the client ID and secret.
+Visit <https://woodpecker-ci.org/docs/administration/configuration/forges/overview> for details about retrieving the client ID and secret.

--- a/doc/PRE_INSTALL_fr.md
+++ b/doc/PRE_INSTALL_fr.md
@@ -1,3 +1,3 @@
 Cette application nécessite la configuration d'une connection à une forge Git à l'installation.
 
-Visitez <https://woodpecker-ci.org/docs/administration/forges/overview> pour savoir comment obtenir l'ID de client et le secret.
+Visitez <https://woodpecker-ci.org/docs/administration/configuration/forges/overview> pour savoir comment obtenir l'ID de client et le secret.


### PR DESCRIPTION
## Problem

Current forge overview link  https://woodpecker-ci.org/docs/administration/forges/overview leads to a HTTP 404 page.
<img width="1300" height="447" alt="image" src="https://github.com/user-attachments/assets/e2cda687-0331-4bbc-9e55-483a276d096c" />


## Solution

Update forge overview link to working link: https://woodpecker-ci.org/docs/administration/configuration/forges/overview .

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
