### PR TITLE
Set SSOwat basic auth header handling

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -17,6 +17,10 @@ ls -lah "$install_dir"
 #=================================================
 ynh_script_progression "Adding system configurations related to $app..."
 
+# Set SSOwat basic auth header handling
+ynh_app_setting_set --key=protect_against_basic_auth_spoofing --value=false
+yunohost app ssowatconf
+
 ynh_config_add_nginx
 
 ynh_config_add_systemd

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -22,6 +22,10 @@ ynh_setup_source --dest_dir="$install_dir"
 #=================================================
 ynh_script_progression "Upgrading system configurations related to $app..."
 
+# Set SSOwat basic auth header handling
+ynh_app_setting_set --key=protect_against_basic_auth_spoofing --value=false
+yunohost app ssowatconf
+
 ynh_config_add_nginx
 
 ynh_config_add_systemd


### PR DESCRIPTION
## Problem

Attempt to fix https://github.com/YunoHost-Apps/woodpecker_ynh/issues/32 .

## Solution

Explicitly set SSOwat basic auth header handling.

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
